### PR TITLE
 Nighthawk-PoC: working https integration envoy test server

### DIFF
--- a/openssl.cnf
+++ b/openssl.cnf
@@ -1,0 +1,25 @@
+[ req ]
+default_bits            = 2048
+distinguished_name      = req_distinguished_name
+
+[ req_distinguished_name ]
+countryName                     = Country Name (2 letter code)
+countryName_default             = AU
+countryName_min                 = 2
+countryName_max                 = 2
+
+stateOrProvinceName             = State or Province Name (full name)
+stateOrProvinceName_default     = Some-State
+
+localityName                    = Locality Name (eg, city)
+
+0.organizationName              = Organization Name (eg, company)
+0.organizationName_default      = Internet Widgits Pty Ltd
+
+organizationalUnitName          = Organizational Unit Name (eg, section)
+
+commonName                      = Common Name (e.g. server FQDN or YOUR name)
+commonName_max                  = 64
+
+emailAddress                    = Email Address
+emailAddress_max                = 64

--- a/test/BUILD
+++ b/test/BUILD
@@ -17,7 +17,8 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "@envoy//test/integration:integration_lib",
-        "//source/exe:nighthawk_client_common_lib"
+        "@envoy//test/server:utility_lib",
+        "//source/exe:nighthawk_client_common_lib",
     ],
 )
 

--- a/test/certs.sh
+++ b/test/certs.sh
@@ -8,3 +8,4 @@ cd "$TEST_CERT_DIR"
 openssl genrsa -out ca_key.pem 2048
 openssl req -new -key ca_key.pem -out ca_cert.csr -batch -sha256
 openssl x509 -req -days 730 -in ca_cert.csr -signkey ca_key.pem -out ca_cert.pem
+

--- a/test/certs.sh
+++ b/test/certs.sh
@@ -1,0 +1,10 @@
+
+set -e
+
+TEST_CERT_DIR="${TEST_TMPDIR}"
+mkdir -p "${TEST_CERT_DIR}"
+cd "$TEST_CERT_DIR"
+
+openssl genrsa -out ca_key.pem 2048
+openssl req -new -key ca_key.pem -out ca_cert.csr -batch -sha256
+openssl x509 -req -days 730 -in ca_cert.csr -signkey ca_key.pem -out ca_cert.pem


### PR DESCRIPTION
This adds a test envoy integration server with working
http and https support. The server serves a static file with
lorem-ipsum content on all requests.

Note: this got a bit messy, and needs cleaning up.