### PR TITLE
Test envoy higher timer res

### DIFF
--- a/nighthawk.code-workspace
+++ b/nighthawk.code-workspace
@@ -62,7 +62,9 @@
 			"typeinfo": "cpp",
 			"utility": "cpp",
 			"valarray": "cpp",
-			"variant": "cpp"
+			"variant": "cpp",
+			"any": "cpp",
+			"shared_mutex": "cpp"
 		},
 		"python.pythonPath": "/usr/bin/python3"
 	}

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -48,6 +48,7 @@ envoy_cc_library(
         "benchmark_client.cc",
         "rate_limiter.cc",
         "sequencer.cc",
+        "streaming_stats.cc",
     ],
     hdrs = [
         "client.h",
@@ -57,6 +58,7 @@ envoy_cc_library(
         "benchmark_client.h",
         "rate_limiter.h",
         "sequencer.h",
+        "streaming_stats.h",
     ],
     visibility = ["//visibility:public"],
     repository = "@envoy",

--- a/source/exe/client.cc
+++ b/source/exe/client.cc
@@ -18,6 +18,7 @@
 #include "exe/benchmark_client.h"
 #include "exe/rate_limiter.h"
 #include "exe/sequencer.h"
+#include "exe/streaming_stats.h"
 
 using namespace std::chrono_literals;
 
@@ -48,72 +49,6 @@ uint32_t determine_cpu_cores_with_affinity() {
 }
 
 } // namespace
-
-StreamingStats::StreamingStats() { clear(); }
-
-void StreamingStats::clear() {
-  n = 0;
-  M1 = M2 = M3 = M4 = 0.0;
-}
-
-void StreamingStats::push(int64_t x) {
-  double delta, delta_n, delta_n2, term1;
-
-  int64_t n1 = n;
-  n++;
-  delta = x - M1;
-  delta_n = delta / n;
-  delta_n2 = delta_n * delta_n;
-  term1 = delta * delta_n * n1;
-  M1 += delta_n;
-  M4 += term1 * delta_n2 * (n * n - 3 * n + 3) + 6 * delta_n2 * M2 - 4 * delta_n * M3;
-  M3 += term1 * delta_n * (n - 2) - 3 * delta_n * M2;
-  M2 += term1;
-}
-
-int64_t StreamingStats::num_values() const { return n; }
-
-double StreamingStats::mean() const { return M1; }
-
-double StreamingStats::variance() const { return M2 / (n - 1.0); }
-
-double StreamingStats::stdev() const { return sqrt(variance()); }
-
-double StreamingStats::skewness() const { return sqrt(double(n)) * M3 / pow(M2, 1.5); }
-
-double StreamingStats::kurtosis() const { return double(n) * M4 / (M2 * M2) - 3.0; }
-
-StreamingStats operator+(const StreamingStats a, const StreamingStats b) {
-  StreamingStats combined;
-
-  combined.n = a.n + b.n;
-
-  double delta = b.M1 - a.M1;
-  double delta2 = delta * delta;
-  double delta3 = delta * delta2;
-  double delta4 = delta2 * delta2;
-
-  combined.M1 = (a.n * a.M1 + b.n * b.M1) / combined.n;
-
-  combined.M2 = a.M2 + b.M2 + delta2 * a.n * b.n / combined.n;
-
-  combined.M3 = a.M3 + b.M3 + delta3 * a.n * b.n * (a.n - b.n) / (combined.n * combined.n);
-  combined.M3 += 3.0 * delta * (a.n * b.M2 - b.n * a.M2) / combined.n;
-
-  combined.M4 = a.M4 + b.M4 +
-                delta4 * a.n * b.n * (a.n * a.n - a.n * b.n + b.n * b.n) /
-                    (combined.n * combined.n * combined.n);
-  combined.M4 += 6.0 * delta2 * (a.n * a.n * b.M2 + b.n * b.n * a.M2) / (combined.n * combined.n) +
-                 4.0 * delta * (a.n * b.M3 - b.n * a.M3) / combined.n;
-
-  return combined;
-}
-
-StreamingStats& StreamingStats::operator+=(const StreamingStats& rhs) {
-  StreamingStats combined = *this + rhs;
-  *this = combined;
-  return *this;
-}
 
 ClientMain::ClientMain(int argc, const char* const* argv) : ClientMain(OptionsImpl(argc, argv)) {}
 
@@ -227,7 +162,7 @@ bool ClientMain::run() {
                                       &sequencer](std::chrono::nanoseconds latency) {
         ASSERT(latency.count() > 0);
         results.push_back(latency.count());
-        streaming_stats.push(latency.count());
+        streaming_stats.addValue(latency.count());
 
         // Report results from the first worker about every one second.
         // TODO(oschaaf): we should only do this in explicit verbose mode because
@@ -236,13 +171,13 @@ bool ClientMain::run() {
         // influence timing of this happening.
         if (((results.size() % options_.requests_per_second()) == 0) && i == 0) {
           ENVOY_LOG(info,
-                    "#{} completions/sec. mean: {}+/-{}us. skewness: {}, kurtosis: {}."
+                    "#{} completions/sec. mean: {}+/-{}us. "
                     "pool connect failures: {}, overflow failures: {}. Replies: Good {}, Bad: "
                     "{}. Stream resets: {}.",
                     sequencer.completions_per_second(),
                     (static_cast<int64_t>(streaming_stats.mean())) / 1000,
                     (static_cast<int64_t>(streaming_stats.stdev())) / 1000,
-                    streaming_stats.skewness(), streaming_stats.kurtosis(),
+
                     client->pool_connect_failures(), client->pool_overflow_failures(),
                     client->http_good_response_count(), client->http_bad_response_count(),
                     client->stream_reset_count());

--- a/source/exe/client.h
+++ b/source/exe/client.h
@@ -11,26 +11,6 @@
 
 namespace Nighthawk {
 
-class StreamingStats {
-public:
-  StreamingStats();
-  void clear();
-  void push(int64_t x);
-  int64_t num_values() const;
-  double mean() const;
-  double variance() const;
-  double stdev() const;
-  double skewness() const;
-  double kurtosis() const;
-
-  friend StreamingStats operator+(const StreamingStats a, const StreamingStats b);
-  StreamingStats& operator+=(const StreamingStats& rhs);
-
-private:
-  int64_t n;
-  double M1, M2, M3, M4;
-};
-
 class ClientMain : public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
 public:
   ClientMain(int argc, const char* const* argv);

--- a/source/exe/client.h
+++ b/source/exe/client.h
@@ -11,6 +11,26 @@
 
 namespace Nighthawk {
 
+class StreamingStats {
+public:
+  StreamingStats();
+  void clear();
+  void push(int64_t x);
+  int64_t num_values() const;
+  double mean() const;
+  double variance() const;
+  double stdev() const;
+  double skewness() const;
+  double kurtosis() const;
+
+  friend StreamingStats operator+(const StreamingStats a, const StreamingStats b);
+  StreamingStats& operator+=(const StreamingStats& rhs);
+
+private:
+  int64_t n;
+  double M1, M2, M3, M4;
+};
+
 class ClientMain : public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
 public:
   ClientMain(int argc, const char* const* argv);

--- a/source/exe/sequencer.h
+++ b/source/exe/sequencer.h
@@ -24,6 +24,11 @@ public:
   void set_latency_callback(std::function<void(std::chrono::nanoseconds)> latency_callback) {
     latency_callback_ = latency_callback;
   }
+  int64_t completions_per_second() {
+    return targets_completed_ /
+           std::chrono::duration_cast<std::chrono::seconds>(time_source_.monotonicTime() - start_)
+               .count();
+  }
 
 protected:
   void run(bool from_timer);
@@ -32,10 +37,8 @@ protected:
 private:
   Envoy::Event::Dispatcher& dispatcher_;
   Envoy::TimeSource& time_source_;
-  Envoy::Event::TimerPtr timer1_;
-  Envoy::Event::TimerPtr timer2_;
-  Envoy::Event::TimerPtr timer3_;
-  Envoy::Event::TimerPtr timer4_;
+  Envoy::Event::TimerPtr periodic_timer_;
+  Envoy::Event::TimerPtr incidental_timer_;
   RateLimiter& rate_limiter_;
   SequencerTarget& target_;
   std::chrono::microseconds duration_;

--- a/source/exe/sequencer.h
+++ b/source/exe/sequencer.h
@@ -32,7 +32,10 @@ protected:
 private:
   Envoy::Event::Dispatcher& dispatcher_;
   Envoy::TimeSource& time_source_;
-  Envoy::Event::TimerPtr timer_;
+  Envoy::Event::TimerPtr timer1_;
+  Envoy::Event::TimerPtr timer2_;
+  Envoy::Event::TimerPtr timer3_;
+  Envoy::Event::TimerPtr timer4_;
   RateLimiter& rate_limiter_;
   SequencerTarget& target_;
   std::chrono::microseconds duration_;

--- a/source/exe/streaming_stats.cc
+++ b/source/exe/streaming_stats.cc
@@ -1,0 +1,24 @@
+#include "exe/streaming_stats.h"
+
+namespace Nighthawk {
+
+StreamingStats::StreamingStats() : count_(0), mean_(0), sum_of_squares_(0) {}
+
+void StreamingStats::addValue(int64_t value) {
+  double delta, delta_n;
+  count_++;
+  delta = value - mean_;
+  delta_n = delta / count_;
+  mean_ += delta_n;
+  sum_of_squares_ += delta * delta_n * (count_ - 1);
+}
+
+int64_t StreamingStats::count() const { return count_; }
+
+double StreamingStats::mean() const { return mean_; }
+
+double StreamingStats::variance() const { return sum_of_squares_ / (count_ - 1.0); }
+
+double StreamingStats::stdev() const { return sqrt(variance()); }
+
+}

--- a/source/exe/streaming_stats.h
+++ b/source/exe/streaming_stats.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+#include <math.h>
+
+namespace Nighthawk {
+
+// TODO(oschaaf): test this class.
+class StreamingStats {
+public:
+  StreamingStats();
+  void addValue(int64_t value);
+  int64_t count() const;
+  double mean() const;
+  double variance() const;
+  double stdev() const;
+
+private:
+  int64_t count_;
+  double mean_;
+  double sum_of_squares_;
+};
+
+} // namespace Nighthawk

--- a/test/sequencer_test.cc
+++ b/test/sequencer_test.cc
@@ -2,7 +2,8 @@
 
 #include "gtest/gtest.h"
 
-#include "test/test_common/simulated_time_system.h"
+//#include "test/test_common/simulated_time_system.h"
+#include "common/event/real_time_system.h"
 
 #include "common/api/api_impl.h"
 #include "common/common/thread_impl.h"
@@ -30,12 +31,18 @@ public:
     return true;
   }
 
-  void SetUp() { time_system_.setMonotonicTime(0ms); }
+  void SetUp() { /*time_system_.setMonotonicTime(0s);*/
+  }
   void TearDown() {}
 
   Envoy::Thread::ThreadFactoryImplPosix thread_factory_;
   Envoy::Stats::IsolatedStoreImpl store_;
-  Envoy::Event::SimulatedTimeSystem time_system_;
+
+  // Simulated time broke when we introduced the spin loop.
+  // Figure that out at some point and restore simulated
+  // time usage here.
+  // Envoy::Event::SimulatedTimeSystem time_system_;
+  Envoy::Event::RealTimeSystem time_system_;
   Envoy::Api::Impl api_;
   Envoy::Event::DispatcherPtr dispatcher_;
   int callback_test_count_;
@@ -47,7 +54,7 @@ TEST_F(SequencerTest, BasicTest) {
 
   Sequencer sequencer(*dispatcher_, time_system_, rate_limiter, f, 1s, 1s);
   sequencer.start();
-  time_system_.setMonotonicTime(std::chrono::milliseconds(1000ms));
+  // time_system_.setMonotonicTime(1s);
   sequencer.waitForCompletion();
   // We ought to have observed 10 callbacks at the 10/second pacing.
   EXPECT_EQ(10, callback_test_count_);


### PR DESCRIPTION
- add test with streaming tracking of mean/stdev and more
- experiment with using multiple timers for scheduling vs impacting measurement accuracy
- Introduce a spin when idle to get a higher accuracy on initiating new
  actions.
- Make SequencerTest use RealTimeSystem instead of SimulatedTimeSystem.
  This avoids a hang that was introduced by the spin loop. Needs
  looking into later.
- Emit #rps from the first worker periodically when performing a
  benchmark run.
- Add a single warmup request / worker.
- experiment with increasing envoys timer res from ms to us. (Got reverted, looks like it doesn't improve, though perhaps it is worth it to redo this on a machine tuned for low latency).
