### PR TITLE
Limit concurrent requests based on outstanding requests instead of trusting on pending_requests

### DIFF
--- a/source/client/benchmark_http_client.h
+++ b/source/client/benchmark_http_client.h
@@ -75,6 +75,9 @@ private:
   uint64_t stream_reset_count_;
   uint64_t http_good_response_count_;
   uint64_t http_bad_response_count_;
+  uint64_t requests_completed_;
+  uint64_t requests_initiated_;
+
 };
 
 } // namespace Client


### PR DESCRIPTION
pending_requests is used for requests waiting for a connection to be setup and the number of requests queued
Because of this we can still queue 1 request when there already is a request running. 
This results in a longer latency (+80ms,+160ms,+240ms) because the item has a start time during the previous request.

I don't know how this will affect H2 benching....

@envoy: discussion is needed whether this is a clean design for HTTP1
a request waiting for a connection, which is being setup, can be seen as a request which already has system resources assigned
a request waiting for a connection  has no promise of resources yet , this is a queued item

So is pending "queued" or is pending "pending for a connection" , setting the max pending to a value has a different result in both cases.

Maybe some extra interfaces are needed to determine the state of a pool?

